### PR TITLE
ticket-27: Add VBN, EM Connectomics, and Allen Brain Observatory S3 mounts.

### DIFF
--- a/roothooks.d/01-setup-s3fs.bash
+++ b/roothooks.d/01-setup-s3fs.bash
@@ -3,8 +3,23 @@
 set -euo pipefail
 
 export NB_UID=1000
+mkdir -p /data/allen-brain-observatory
+mkdir -p /data/em-connectomics-data
+mkdir -p /data/visual-behavior-neuropixels-data
 mkdir -p /data/visual-behavior-ophys-data
 
+s3fs allen-brain-observatory \
+    /data/allen-brain-observatory \
+    -o default_acl="public-read" \
+    -o complement_stat,uid=${NB_UID},gid=${NB_UID},umask=0222,allow_other,public_bucket="1",endpoint="us-west-2"
+s3fs em-connectomics-data \
+    /data/em-connectomics-data \
+    -o default_acl="public-read" \
+    -o complement_stat,uid=${NB_UID},gid=${NB_UID},umask=0222,allow_other,public_bucket="1",endpoint="us-west-2"
+s3fs visual-behavior-neuropixels-data \
+    /data/visual-behavior-neuropixels-data \
+    -o default_acl="public-read" \
+    -o complement_stat,uid=${NB_UID},gid=${NB_UID},umask=0222,allow_other,public_bucket="1",endpoint="us-west-2"
 s3fs visual-behavior-ophys-data \
     /data/visual-behavior-ophys-data \
     -o default_acl="public-read" \


### PR DESCRIPTION
Added new dataset mounts. @yuvipanda can you double check that I've got the mounts all added correctly and confirm that I don't need to add anything to another scripts.

@mabuice Can you confirm that the datasets you requested are being added? I believe the Visual Coding 2P/NP data is in the `allen-brain-observatory` mount. The EM connectomics data is still to be uploaded so the directory will be empty for now.